### PR TITLE
Adding How to access additional metafields data in section 

### DIFF
--- a/for-developers/how-to-guides/access-additional-metafields.mdx
+++ b/for-developers/how-to-guides/access-additional-metafields.mdx
@@ -1,0 +1,94 @@
+---
+title: 'How to access additional metafields in V3 Template'
+description: 'Learn how to access and use additional metafields in your V3 Template implementation'
+---
+
+## Overview
+
+In V3 Template, products are fetched using GraphQL. While default product data is automatically included, accessing additional metafields requires three steps:
+
+1. Adding metafields to the `getProductDetailsQuery` function
+2. Including metafields in the `transformProductData` function
+3. Accessing the metafields in your template's theme.liquid
+
+## Basic Implementation
+
+### Step 1: Modify getProductDetailsQuery
+
+Add your metafields to the GraphQL query in the `getProductDetailsQuery` function:
+
+```javascript
+getProductDetailsQuery: (recommendation, glood) => {
+  return `
+    featuredImage {
+      url
+    }
+    handle
+    id
+    title
+    # Add your metafields here
+    metafield(namespace: "custom", key: "product_info") {
+      value
+    }
+    # Rest of your existing query
+    variants(first: 250) {
+      nodes {
+        id
+        # ... other variant fields
+      }
+    }
+  `
+}
+```
+
+### Step 2: Update transformProductData
+
+Modify the `transformProductData` function to include your metafields:
+
+```javascript
+transformProductData: (product) => {
+  return {
+    featuredImage: product.featuredImage.url
+      ? {
+          src: product.featuredImage.url,
+        }
+      : null,
+    handle: product.handle,
+    id: parseInt(product.id.replace('gid://shopify/Product/', '')),
+    title: product.title,
+    // Add your metafield transformation
+    metafield_value: product.metafield ? product.metafield.value : "N/A",
+    // Rest of your existing transformations
+    variants: product.variants.nodes.map((variant) => ({
+      // ... variant transformations
+    }))
+  }
+}
+```
+
+### Step 3: Access in Theme
+
+Use the transformed metafield in your theme.liquid:
+
+```liquid
+{% raw %}
+<div class="_gai-prod-dtls">
+  <div class="_gai-full-width">
+    <a class="_gai-prod-tit" href="{{ product_url }}">
+      {{ product.title }}
+    </a>
+    {% if product.metafield and product.metafield.value %}
+      <p>Extra Info: {{ product.metafield.value }}</p>
+    {% else %}
+      <p>Information unavailable.</p>
+    {% endif %}
+  </div>
+</div>
+{% endraw %}
+```
+
+## Related Resources
+
+- [Section Template Introduction](/for-developers/section-template/introduction)
+- [Template Tags](/for-developers/section-template/tags)
+- [Template Hooks](/for-developers/section-template/hooks) 

--- a/for-developers/how-to-guides/access-additional-metafields.mdx
+++ b/for-developers/how-to-guides/access-additional-metafields.mdx
@@ -87,6 +87,29 @@ Use the transformed metafield in your theme.liquid:
 {% endraw %}
 ```
 
+## Practical Example: Product Ratings with Judge.me
+
+### Prerequisites
+
+1. Install Judge.me app on your Shopify store:
+   - Go to Shopify App Store and install Judge.me
+   - Enable the app integration in your store settings
+
+2. Enable Judge.me in Glood:
+   - Navigate to Glood Product Recommendations
+   - Go to Settings >> Integrations >> Product Review Apps
+   - Enable the Judge.me app integration
+
+After completing the setup, the rating metafields will be available in your GraphQL queries. You can query these metafields using the reviews namespace wherever needed.
+
+To display product ratings in your template, simply use the Judge.me liquid tag:
+
+```liquid
+{% raw %}
+{% product_ratings product_id: product.id %}
+{% endraw %}
+```
+
 ## Related Resources
 
 - [Section Template Introduction](/for-developers/section-template/introduction)

--- a/mint.json
+++ b/mint.json
@@ -64,7 +64,7 @@
       "group": "Documentation",
       "pages": [
         "introduction",
-        "releases"
+        "development"
       ]
     },
     {
@@ -111,19 +111,11 @@
           ]
         },
         {
-          "group": "Integrations",
-          "pages": [
-            "for-developers/integrations/introduction",
-            "for-developers/integrations/wishlist",
-            "for-developers/integrations/product-ratings",
-            "for-developers/integrations/quick-view"
-          ]
-        },
-        {
           "group": "How to guides",
           "pages": [
             "for-developers/how-to-guides/introduction",
-            "for-developers/how-to-guides/add-sections-to-mini-cart"
+            "for-developers/how-to-guides/add-sections-to-mini-cart",
+            "for-developers/how-to-guides/access-additional-metafields"
           ]
         }
       ]

--- a/mint.json
+++ b/mint.json
@@ -64,6 +64,7 @@
       "group": "Documentation",
       "pages": [
         "introduction",
+        "releases",
         "development"
       ]
     },
@@ -108,6 +109,15 @@
             "for-developers/section-template/filters",
             "for-developers/section-template/tags",
             "for-developers/section-template/hooks"
+          ]
+        },
+        {
+          "group": "Integrations",
+          "pages": [
+            "for-developers/integrations/introduction",
+            "for-developers/integrations/wishlist",
+            "for-developers/integrations/product-ratings",
+            "for-developers/integrations/quick-view"
           ]
         },
         {

--- a/mint.json
+++ b/mint.json
@@ -64,8 +64,7 @@
       "group": "Documentation",
       "pages": [
         "introduction",
-        "releases",
-        "development"
+        "releases"
       ]
     },
     {


### PR DESCRIPTION
Adding How to access additional metafields data in section under how-to-guide.

![image](https://github.com/user-attachments/assets/fd7da2ad-b9ed-4f46-a2d4-d2a25f28a647)
