### PR TITLE
Added docs for how to enable swatches in v3 template

### DIFF
--- a/for-developers/how-to-guides/enable-swatch-v3-template.mdx
+++ b/for-developers/how-to-guides/enable-swatch-v3-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Enable Swatch in v3 Template'
+title: 'Enable Swatch in V3 Template'
 description: 'Learn how to enable and configure swatch functionality in your v3 template'
 ---
 Swatches provide a visual way for customers to select product variants, especially useful for color and material options. This guide will show you how to enable and configure swatches in your v3 template.

--- a/for-developers/how-to-guides/enable-swatch-v3-template.mdx
+++ b/for-developers/how-to-guides/enable-swatch-v3-template.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Enable Swatch in v3 Template'
+description: 'Learn how to enable and configure swatch functionality in your v3 template'
+---
+Swatches provide a visual way for customers to select product variants, especially useful for color and material options. This guide will show you how to enable and configure swatches in your v3 template.
+
+## Basic Configuration
+
+To enable swatches in your template, you need to modify the `variantSelectorType` setting to "swatch". This will automatically convert your variant selectors to swatch format.
+
+```json
+{
+  "variantSelectorType": "swatch"
+}
+```
+
+## Color Mapping
+
+When using swatches for colors, Glood first checks if the product color is a valid CSS color. If it's not valid, it looks up the color in the color mapping configuration.
+
+### Why Use Color Mapping?
+
+Color mapping is essential when your store uses custom color names that aren't valid CSS colors. For example, if your store uses color names like "limestone green" or "cityscape", you'll need to map these to valid CSS colors.
+
+### Example Configuration
+
+Here's how to set up color mapping:
+
+```json
+{
+  "colorMapping": {
+   "limestoneGreen": "#348221"
+  }
+}
+```
+
+### How Color Mapping Works
+
+1. When a product variant has a color option, Glood first checks if it's a valid CSS color
+2. If the color is valid (e.g., "red", "#FF0000", "rgb(255, 0, 0)"), it's used directly
+3. If the color is not valid (e.g., "limestone green"), Glood looks up the corresponding value in the colorMapping
+4. The mapped color is then used for the swatch display
+
+## Troubleshooting
+
+If swatches aren't displaying correctly:
+
+1. Verify that `variantSelectorType` is set to "swatch"
+2. Check that all custom color names are properly mapped
+3. Ensure the color values in the mapping are valid CSS colors
+4. Clear your store's cache to ensure changes take effect
+
+## Support
+
+If you need help with enabling or customizing swatches in your v3 template, contact our support team at support@glood.ai 

--- a/for-developers/how-to-guides/enable-swatch-v3-template.mdx
+++ b/for-developers/how-to-guides/enable-swatch-v3-template.mdx
@@ -4,7 +4,7 @@ description: 'Learn how to enable and configure swatch functionality in your v3 
 ---
 Swatches provide a visual way for customers to select product variants, especially useful for color and material options. This guide will show you how to enable and configure swatches in your v3 template.
 
-## Basic Configuration
+## 1. Basic Configuration
 
 To enable swatches in your template, you need to modify the `variantSelectorType` setting to "swatch". This will automatically convert your variant selectors to swatch format.
 
@@ -49,6 +49,35 @@ If swatches aren't displaying correctly:
 2. Check that all custom color names are properly mapped
 3. Ensure the color values in the mapping are valid CSS colors
 4. Clear your store's cache to ensure changes take effect
+
+## 2. Quick Add-to-Cart Swatches
+
+For a more streamlined shopping experience, you can enable swatches that automatically add products to cart when clicked. This is particularly useful in recommendation sections or quick-shop scenarios.
+
+### Configuration
+
+To enable quick add-to-cart swatches, set the `variantSelectorType` to "swatch_with_atc":
+
+```json
+{
+  "variantSelectorType": "swatch_with_atc"
+}
+```
+
+### How It Works
+
+1. When a customer clicks on a swatch, the system automatically:
+   - Selects the corresponding variant
+   - Adds the product to cart immediately
+
+### Troubleshooting Quick Add-to-Cart Swatches
+
+If the automatic add-to-cart isn't working:
+
+1. Verify that `variantSelectorType` is set to "swatch_with_atc"
+2. Ensure the variant is in stock
+3. Check that the cart is properly initialized
+4. Clear the store's cache after making configuration changes
 
 ## Support
 

--- a/for-developers/section-template/schemas.mdx
+++ b/for-developers/section-template/schemas.mdx
@@ -28,7 +28,7 @@ The glood object provides essential store information and configuration settings
 ### Core Properties
 | Key | Type | Description | Default Value |
 |-----|------|-------------|---------------|
-| `shopify.root_url` | string | Base URL of the Shopify store | "/" |
+| `shopify.rootUrl` | string | Base URL of the Shopify store | "/" |
 
 
 ### Localization Properties
@@ -36,7 +36,7 @@ The glood object provides essential store information and configuration settings
 |-----|------|-------------|---------------|
 | `localization.language.locale` | string | Language code | "en" |
 | `localization.language.primary` | boolean | Whether this is primary language | true |
-| `localization.language.root_url` | string | Base URL for language | "/" |
+| `localization.language.rootUrl` | string | Base URL for language | "/" |
 | `localization.country` | string | Country code | "IN" |
 | `localization.currency` | string | Currency code | "INR" |
 
@@ -51,10 +51,10 @@ The glood object provides essential store information and configuration settings
 |-----|------|-------------|---------------|
 | `shop.domain` | string | Store's domain | "adarsh-test2-store.myshopify.com" |
 | `shop.id` | string | Shop identifier | "73540239597" |
-| `shop.products_count` | number | Total number of products | 15 |
-| `shop.currency_rate` | string | Currency conversion rate | "1.0" |
-| `shop.money_format` | string | Store's currency format | `"Rs. \{\{amount\}\}"` |
-| `shop.currency_code` | string | Store's currency code | "INR" |
+| `shop.productsCount` | number | Total number of products | 15 |
+| `shop.currencyRate` | string | Currency conversion rate | "1.0" |
+| `shop.moneyFormat` | string | Store's currency format | `"Rs. \{\{amount\}\}"` |
+| `shop.currencyCode` | string | Store's currency code | "INR" |
 
 ### Product Properties
 | Key | Type | Description | Default Value |
@@ -71,16 +71,16 @@ The glood object provides essential store information and configuration settings
 | Key | Type | Description | Default Value |
 |-----|------|-------------|---------------|
 | `cart.currency` | string | Cart currency | "INR" |
-| `cart.item_count` | number | Number of items in cart | 16 |
-| `cart.total_price` | number | Total cart price | 752945 |
-| `cart.requires_shipping` | boolean | Whether cart requires shipping | true |
-| `cart.total_weight` | number | Total cart weight | 250 |
+| `cart.itemCount` | number | Number of items in cart | 16 |
+| `cart.totalPrice` | number | Total cart price | 752945 |
+| `cart.requiresShipping` | boolean | Whether cart requires shipping | true |
+| `cart.totalWeight` | number | Total cart weight | 250 |
 
 ### Config Properties
 | Key | Type | Description | Default Value |
 |-----|------|-------------|---------------|
-| `config.page_type` | string | Type of current page | "product" |
-| `config.page_url` | string | Current page URL | "adarsh-test2-store.myshopify.com/products/soap" |
+| `config.pageType` | string | Type of current page | "product" |
+| `config.pageUrl` | string | Current page URL | "adarsh-test2-store.myshopify.com/products/soap" |
 | `config.uid` | string | Unique identifier | "1737978965-cd63b5e8-9f99-4519-a4bc-b0dac71ccead" |
 
 **NOTE:** 
@@ -94,8 +94,8 @@ The glood object provides essential store information and configuration settings
 
 Example usage in Liquid:
 ```liquid
-{{ glood.shop.money_format }}
-{{ glood.localization.language.root_url }}
+{{ glood.shop.moneyFormat }}
+{{ glood.localization.language.rootUrl }}
 ```
 
 ## `products` Array
@@ -118,23 +118,23 @@ The products array is responsible for:
 | `handle` | string | Product URL handle | "coconut-bar-soap" |
 | `vendor` | string | Product vendor name | "Natural Essentials" |
 | `tags` | array | Product tags | ["new", "organic", "bestseller"] |
-| `featured_image.src` | string | Main product image URL | "https://cdn.shopify.com/s/files/1/soap.jpg" |
+| `featuredImage.src` | string | Main product image URL | "https://cdn.shopify.com/s/files/1/soap.jpg" |
 | `images[].src` | string | Additional image URLs | ["https://cdn.shopify.com/s/files/1/soap-1.jpg"] |
 | `variants` | array | Product variants | [See variant example below] |
 | `variants[].id` | string | Variant identifier | "40468007231725" |
 | `variants[].title` | string | Variant title | "Small / Blue" |
-| `variants[].available_for_sale` | boolean | Stock availability | true |
+| `variants[].availableForSale` | boolean | Stock availability | true |
 | `variants[].price` | string | Variant price | "19.99" |
-| `variants[].compare_at_price` | string | Original price | "24.99" |
+| `variants[].compareAtPrice` | string | Original price | "24.99" |
 | `variants[].image.src` | string | Variant image URL | "https://cdn.shopify.com/s/files/1/blue-soap.jpg" |
-| `variants[].selected_options` | array | Selected variant options | [See options example below] |
-| `variants[].selected_options[].name` | string | Option name | "Size" |
-| `variants[].selected_options[].value` | string | Option value | "Small" |
+| `variants[].selectedOptions` | array | Selected variant options | [See options example below] |
+| `variants[].selectedOptions[].name` | string | Option name | "Size" |
+| `variants[].selectedOptions[].value` | string | Option value | "Small" |
 | `options` | array | Product options | [See options example below] |
 | `options[].name` | string | Option name | "Size" |
-| `options[].option_values` | array | Available option values | ["Small", "Medium", "Large"] |
-| `show_compare_price` | boolean | Show compare at price | true |
-| `first_variant` | object | First available variant | [See variant example above] |
+| `options[].optionValues` | array | Available option values | ["Small", "Medium", "Large"] |
+| `showComparePrice` | boolean | Show compare at price | true |
+| `firstVariant` | object | First available variant | [See variant example above] |
 
 **NOTE:** Product array structure is not fixed and it can be changed. If you want to change product array, you can visit the [transformProductData hook](/for-developers/section-template/hooks#4-transformproductdata) in the hooks section.
 
@@ -151,16 +151,16 @@ The translations object serves multiple purposes:
 
 | Key | Type | Description | Default Value |
 |-----|------|-------------|---------------|
-| `oos_text` | string | Out of stock message | "Out of stock" |
-| `added_to_cart_text` | string | Success message for cart addition | "Added to cart" |
-| `atc_error_text` | string | Error message for cart addition | "Error adding to cart" |
-| `atc_text` | string | Add to cart button text | "Add to cart" |
-| `total_price_text` | string | Total price label | "Total price" |
-| `fbt_add_to_cart_text` | string | Bundle add to cart text | "Add bundle to cart" |
-| `fbt_added_to_cart_text` | string | Bundle success message | "Bundle added to cart" |
-| `discount_label_text` | string | Discount label text | "Save {discount}" |
-| `discount_save_text` | string | Savings amount text | "Save {amount}" |
-| `fbt_save_text` | string | Bundle savings text | "Save {amount} with this bundle" |
+| `oosText` | string | Out of stock message | "Out of stock" |
+| `addedToCartText` | string | Success message for cart addition | "Added to cart" |
+| `atcErrorText` | string | Error message for cart addition | "Error adding to cart" |
+| `atcText` | string | Add to cart button text | "Add to cart" |
+| `totalPriceText` | string | Total price label | "Total price" |
+| `fbtAddToCartText` | string | Bundle add to cart text | "Add bundle to cart" |
+| `fbtAddedToCartText` | string | Bundle success message | "Bundle added to cart" |
+| `discountLabelText` | string | Discount label text | "Save {discount}" |
+| `discountSaveText` | string | Savings amount text | "Save {amount}" |
+| `fbtSaveText` | string | Bundle savings text | "Save {amount} with this bundle" |
 | `new` | string | New product badge text | "New" |
 | `trending` | string | Trending product badge text | "Trending" |
 | `bestseller` | string | Bestseller badge text | "Bestseller" |
@@ -189,12 +189,12 @@ The section object is crucial for:
 | `title` | string | Section heading text | "You May Also Like" |
 | `template` | string | Template identifier | "default" |
 | `extra` | object | Additional section configuration | `{"maxProducts":4}` |
-| `discount_config` | object | Discount settings | `{"type":"percentage","value":20}` |
-| `show_discount_label` | boolean | Display discount labels | true |
-| `translations` | object | Section-specific translations | `{"discount_text":"Save"}` |
-| `template_v3` | boolean | Using template version 3 | true |
-| `section_serve_id` | string | Unique serve identifier | "s-12345-abcd-9876" |
-| `page_type` | string | Page section appears on | "product" |
+| `discountConfig` | object | Discount settings | `{"type":"percentage","value":20}` |
+| `showDiscountLabel` | boolean | Display discount labels | true |
+| `translations` | object | Section-specific translations | `{"discountText":"Save"}` |
+| `templateV3` | boolean | Using template version 3 | true |
+| `sectionServeId` | string | Unique serve identifier | "s-12345-abcd-9876" |
+| `pageType` | string | Page section appears on | "product" |
 
 ## `template` Object
 The template object is your control center for visual styling and responsive behavior.
@@ -228,20 +228,20 @@ The template object is responsible for:
 | `settings.breakpoints[].widgetTitleFontSize` | number | Section title font size | `24` | 24 |
 | `settings.breakpoints[].productTitleFontSize` | number | Product title font size | `16` | 16 |
 | `settings.breakpoints[].productVendorFontSize` | number | Vendor name font size | `14` | 14 |
-| `settings.product_card.vendorPosition` | enum | Vendor position | `"above"`, `"below"`, `"hidden"` | hidden |
-| `settings.product_card.addToCartMode` | enum | Add to cart behavior | `"card_hover"`, `"image_hover"`, `"fix"` | card_hover |
-| `settings.product_card.imageHoverMode` | enum | Image hover effect | `"secondary"`, `"zoom"`, `"none"` | secondary |
-| `settings.product_card.imageObjectFit` | enum | Image fitting mode | `"contain"`, `"cover"` | contain |
-| `settings.product_card.priceCompareMode` | enum | Compare price position | `"before"`, `"after"`, `"hidden"` | before |
-| `settings.product_card.discountLabelPosition` | enum | Discount badge position | `"left"`, `"right"`, `"center"` | center |
-| `settings.product_card.variantSelectorType` | enum | Variant selection UI | `"integrated"`, `"selector"`, `"swatch"` | integrated |
-| `settings.product_card.showQuantitySelector` | boolean | Show quantity selector | `true`, `false` | false |
-| `settings.product_card.minQuantity` | number | Minimum order quantity | `1` |  |
-| `settings.product_card.maxQuantity` | number | Maximum order quantity | `10` |  |
-| `settings.product_card.imageAspectRatio` | string | Image aspect ratio | `"1:1"` |  |
-| `settings.product_card.showVendor` | boolean | Show/hide vendor name | `true` |  |
-| `settings.product_card.maxTitleLines` | number | Maximum product title lines | `2` |  |
-| `settings.product_card.showDiscountPill` | boolean | Show/hide discount badge | `true` |  |
+| `settings.productCard.vendorPosition` | enum | Vendor position | `"above"`, `"below"`, `"hidden"` | hidden |
+| `settings.productCard.addToCartMode` | enum | Add to cart behavior | `"card_hover"`, `"image_hover"`, `"fix"` | card_hover |
+| `settings.productCard.imageHoverMode` | enum | Image hover effect | `"secondary"`, `"zoom"`, `"none"` | secondary |
+| `settings.productCard.imageObjectFit` | enum | Image fitting mode | `"contain"`, `"cover"` | contain |
+| `settings.productCard.priceCompareMode` | enum | Compare price position | `"before"`, `"after"`, `"hidden"` | before |
+| `settings.productCard.discountLabelPosition` | enum | Discount badge position | `"left"`, `"right"`, `"center"` | center |
+| `settings.productCard.variantSelectorType` | enum | Variant selection UI | `"integrated"`, `"selector"`, `"swatch"` | integrated |
+| `settings.productCard.showQuantitySelector` | boolean | Show quantity selector | `true`, `false` | false |
+| `settings.productCard.minQuantity` | number | Minimum order quantity | `1` |  |
+| `settings.productCard.maxQuantity` | number | Maximum order quantity | `10` |  |
+| `settings.productCard.imageAspectRatio` | string | Image aspect ratio | `"1:1"` |  |
+| `settings.productCard.showVendor` | boolean | Show/hide vendor name | `true` |  |
+| `settings.productCard.maxTitleLines` | number | Maximum product title lines | `2` |  |
+| `settings.productCard.showDiscountPill` | boolean | Show/hide discount badge | `true` |  |
 | `settings.labels` | array | Product label configurations | See labels example |  |
 | `settings.labels[].name` | string | Label name | `"new"`, `"sale"` |  |
 | `settings.labels[].textColor` | string | Label text color | `"#ffffff"` |  |
@@ -253,10 +253,10 @@ The template object is responsible for:
 | `settings.swatches[].optionNames` | array | Valid option names | `["Color", "Colour"]` |  |
 | `settings.carousel.library` | string | Carousel library to use | `"swiper"` |  |
 | `settings.carousel.showPagination` | boolean | Show carousel pagination | `true`, `false` | false |
-| `settings.amazon_bought_together.priceCompareAtMode` | enum | Bundle price compare mode | `"before"`, `"after"` | before |
-| `settings.amazon_bought_together.buttonBackgroundColor` | string | Bundle button background | `"#000000"` |  |
+| `settings.amazonBoughtTogether.priceCompareAtMode` | enum | Bundle price compare mode | `"before"`, `"after"` | before |
+| `settings.amazonBoughtTogether.buttonBackgroundColor` | string | Bundle button background | `"#000000"` |  |
 | `translations` | object | Section-specific translations | See translations object | |
-| `settings.intl_options` | object | Locale based currency formatting options | Intl DOM API options | {} |
+| `settings.intlOptions` | object | Locale based currency formatting options | Intl DOM API options | {} |
 
 **NOTE:** 
 1. `addToCartMode` behavior options:
@@ -264,7 +264,7 @@ The template object is responsible for:
    - `image_hover`: Add to cart button appears over the product image on hover
    - `fix`: Add to cart button is always visible below the product details
 2. The `translations` key in this table refers to the same structure as the [translations object](/for-developers/section-template/schemas#translations-object).
-3. Example intl_options:
+3. Example intlOptions:
    ```json
    {
       "en": {
@@ -314,10 +314,10 @@ The config object controls:
 
 | Key | Type | Description | Possible Values |
 |-----|------|-------------|---------|
-| `config.integrations_enabled` | array | List of enabled integration slugs | `["judge_me", "loox", "stamped", "rivyo", "okendo", "ali", "ssw", "ryviu", "spr", "lai", "junip"]` |
-| `config.product_review_app` | string | Selected product review app name | `"judge_me", "loox", "stamped", "rivyo", "okendo", "ali", "ryviu", "lai", "junip" (or none if not using reviews)` |
-| `config.swatch_app` | string | Selected swatch app name | `"variant_options_swatch_king", "csp" (or none if not using swatches)` |
+| `config.integrationsEnabled` | array | List of enabled integration slugs | `["judge_me", "loox", "stamped", "rivyo", "okendo", "ali", "ssw", "ryviu", "spr", "lai", "junip"]` |
+| `config.productReviewApp` | string | Selected product review app name | `"judge_me", "loox", "stamped", "rivyo", "okendo", "ali", "ryviu", "lai", "junip" (or none if not using reviews)` |
+| `config.swatchApp` | string | Selected swatch app name | `"variant_options_swatch_king", "csp" (or none if not using swatches)` |
 
 ## Support
 
-For help with template customization or troubleshooting, contact our support team at support@glood.ai 
+For help with template customization or troubleshooting, contact our support team at support@glood.ai

--- a/mint.json
+++ b/mint.json
@@ -124,7 +124,8 @@
           "pages": [
             "for-developers/how-to-guides/introduction",
             "for-developers/how-to-guides/add-sections-to-mini-cart",
-            "for-developers/how-to-guides/access-additional-metafields"
+            "for-developers/how-to-guides/access-additional-metafields",
+            "for-developers/how-to-guides/enable-swatch-v3-template"
           ]
         },
         {


### PR DESCRIPTION
1. Added how to enable swatches in v3 template under how-to-guides.
2. Made changes in schemas.mdx file: changed template keys from snake_case to camelCase.


![image](https://github.com/user-attachments/assets/558e3faf-3790-40e7-a141-e74b2db61c41)
