### PR TITLE
Enable minicart & labels

### DIFF
--- a/for-developers/how-to-guides/enable-labels.mdx
+++ b/for-developers/how-to-guides/enable-labels.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Enable Labels on Store'
+description: 'Learn how to configure and enable product labels in your store'
+---
+
+## Configuration
+
+### Settings Configuration
+Configure your labels in `settings.json`. Each label has a name, text color, and background color:
+
+```json
+"labels": [
+  {
+    "name": "new",
+    "textColor": "#ffffff",
+    "backgroundColor": "#333333"
+  },
+  {
+    "name": "trending",
+    "textColor": "#ffffff",
+    "backgroundColor": "#444444"
+  },
+  {
+    "name": "bestseller",
+    "textColor": "#ffffff",
+    "backgroundColor": "#222222"
+  }
+],
+"maxLabelsCount": 2
+```
+
+### Template Implementation
+Add this code to your `theme.liquid` to display labels on products. The code checks for matching tags and applies the configured styling:
+
+```liquid
+{% assign labels_cnt = 0 %}
+{% for label in template.settings.labels %}
+  {% if labels_cnt < template.settings.max_labels_count and product.tags contains label.name %}
+    <span class="_gai-pill _gai-{{ label.name }}">
+      {{- translations[label.name] | default: label.name -}}
+    </span>
+    {% assign labels_cnt = labels_cnt | plus: 1 %}
+  {% endif %}
+{% endfor %}
+```
+
+## How It Works
+
+1. Add tags to your products (e.g., "new", "trending", "bestseller") - These tags should match the label names in your settings
+2. Labels will automatically appear on products with matching tags - The system checks product tags against configured label names
+3. Each product shows max 2 labels (configurable via `maxLabelsCount`) - Adjust this number in settings to show more or fewer labels
+4. Labels use the colors defined in settings - Each label type has its own text and background colors
+5. Supports translations through the `translations` object - Use translations to display labels in different languages
+
+## Support
+
+Need help with labels? Contact support@glood.ai 

--- a/for-developers/how-to-guides/open-mini-cart-on-add-to-cart.mdx
+++ b/for-developers/how-to-guides/open-mini-cart-on-add-to-cart.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Open Mini Cart on Add to Cart'
+description: 'Learn how to enable the mini cart to automatically open when clicking the add to cart button'
+---
+
+## Overview
+
+This guide will show you how to configure your sections to automatically open the mini cart when a customer clicks the add to cart button. This feature provides immediate feedback to customers and makes it easier for them to review their cart contents.
+
+## Implementation
+
+### Template Code Hook
+Add the following code to your template's JavaScript hooks. This code will be triggered whenever a product is added to cart:
+
+```javascript
+loadAjaxCart: (bodyElem) => {
+    const ajaxCart = bodyElem.querySelector('#drawer-cart');
+    return ajaxCart.classList.contains("drawer--visible");
+  },
+
+  // Unload recommendations when mini cart closes
+  unloadAjaxCart: (bodyElem) => {
+    const ajaxCart = bodyElem.querySelector('#drawer-cart');
+    return !ajaxCart.classList.contains("drawer--visible");
+  },
+  onCartOperationComplete: (args, utils, gloodUtils) => {
+    setTimeout(() => {
+      document.dispatchEvent(new CustomEvent('theme:cart:init', { bubbles: true }));
+      document.dispatchEvent(new CustomEvent('theme:cart:reload', {
+        bubbles: true
+      }));
+       window.dispatchDrawerEvent('drawer-cart', 'open');
+    }, 1000);
+  }
+```
+
+## How It Works
+
+1. The `loadAjaxCart` function checks if the mini cart is currently visible by looking for the `drawer--visible` class
+2. The `unloadAjaxCart` function handles the opposite case, checking when the mini cart should be closed
+3. When a cart operation completes, `onCartOperationComplete` is triggered:
+   - It dispatches `theme:cart:init` event to initialize the cart
+   - It dispatches `theme:cart:reload` event to refresh cart contents
+   - It opens the mini cart drawer using `dispatchDrawerEvent`
+   - A 1-second delay ensures smooth operation
+
+## Support
+
+If you need help with implementing this feature, contact our support team at support@glood.ai 

--- a/for-developers/how-to-guides/open-mini-cart-on-add-to-cart.mdx
+++ b/for-developers/how-to-guides/open-mini-cart-on-add-to-cart.mdx
@@ -9,8 +9,8 @@ This guide will show you how to configure your sections to automatically open th
 
 ## Implementation
 
-### Template Code Hook
-Add the following code to your template's JavaScript hooks. This code will be triggered whenever a product is added to cart:
+### Add Functions to Hook
+Add these functions to your template's JavaScript hooks:
 
 ```javascript
 loadAjaxCart: (bodyElem) => {
@@ -33,6 +33,14 @@ loadAjaxCart: (bodyElem) => {
     }, 1000);
   }
 ```
+
+### Theme-Specific Implementation
+For this to work, you need to find and use the correct selectors and events from your theme's code:
+
+1. Find the mini cart drawer element in your theme (usually has a class like `drawer-cart` or `mini-cart`)
+2. Identify the correct class that indicates the cart is visible (often `drawer--visible` or similar)
+3. Locate the theme's cart initialization and reload events
+4. Find the correct drawer event dispatch method
 
 ## How It Works
 

--- a/mint.json
+++ b/mint.json
@@ -125,7 +125,9 @@
             "for-developers/how-to-guides/introduction",
             "for-developers/how-to-guides/add-sections-to-mini-cart",
             "for-developers/how-to-guides/access-additional-metafields",
-            "for-developers/how-to-guides/enable-swatch-v3-template"
+            "for-developers/how-to-guides/enable-swatch-v3-template",
+            "for-developers/how-to-guides/open-mini-cart-on-add-to-cart",
+            "for-developers/how-to-guides/enable-labels"
           ]
         },
         {


### PR DESCRIPTION
Added docs for the mini cart and labels.
![image](https://github.com/user-attachments/assets/a43424ef-e281-4848-87d0-1fd8c856c103)

![image](https://github.com/user-attachments/assets/a5e17906-ea43-4956-8b34-2a7e197a8b8d)
